### PR TITLE
fix Timestamp not properly BSON (un)marshalling

### DIFF
--- a/timeutil/timestamp.go
+++ b/timeutil/timestamp.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strconv"
 	"time"
+
+	"gopkg.in/mgo.v2/bson"
 )
 
 // Credit to Gal Ben-Heim, from this post:
@@ -37,6 +39,16 @@ func (t *Timestamp) UnmarshalJSON(b []byte) error {
 	*t = Timestamp{time.Unix(ts, 0)}
 
 	return nil
+}
+
+// GetBSON implements the bson.Getter interface
+func (t Timestamp) GetBSON() (interface{}, error) {
+	return t.Time, nil
+}
+
+// SetBSON implements the bson.Setter interface
+func (t *Timestamp) SetBSON(raw bson.Raw) error {
+	return raw.Unmarshal(&t.Time)
 }
 
 // TimestampNow is simply a wrapper around time.Now which returns a Timestamp.

--- a/timeutil/timestamp_test.go
+++ b/timeutil/timestamp_test.go
@@ -5,6 +5,8 @@ import (
 	"strconv"
 	. "testing"
 
+	"gopkg.in/mgo.v2/bson"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -27,4 +29,21 @@ func TestTimestamp(t *T) {
 	err = json.Unmarshal(tsJ, &ts3)
 	require.Nil(t, err)
 	assert.Equal(t, ts, ts3)
+}
+
+func TestTimestampBSON(t *T) {
+	type Foo struct {
+		T Timestamp `bson:"t"`
+	}
+
+	now := TimestampNow()
+	in := Foo{now}
+	b, err := bson.Marshal(in)
+	require.Nil(t, err)
+	assert.NotEmpty(t, b)
+
+	var out Foo
+	err = bson.Unmarshal(b, &out)
+	require.Nil(t, err)
+	assert.Equal(t, in, out)
 }


### PR DESCRIPTION
I tested this on an actual mongo instance as well
