### PR TITLE
implement RequestIP which handles X-Forwarded-For, use it in RequestKV as well

### DIFF
--- a/rpcutil/rpcutil.go
+++ b/rpcutil/rpcutil.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net"
 	"net/http"
 
 	"gopkg.in/validator.v2"
@@ -19,10 +18,8 @@ import (
 // RequestKV returns a basic KV for passing into llog, filled with entries
 // related to the passed in http.Request
 func RequestKV(r *http.Request) llog.KV {
-	// TODO maybe handle X-Forwarded-For? gotta talk to james
-	ip, _, _ := net.SplitHostPort(r.RemoteAddr)
 	return llog.KV{
-		"ip": ip,
+		"ip": RequestIP(r),
 	}
 }
 

--- a/rpcutil/xff.go
+++ b/rpcutil/xff.go
@@ -1,0 +1,62 @@
+package rpcutil
+
+import (
+	"net"
+	"net/http"
+	"strings"
+)
+
+func mustGetCIDRNetwork(cidr string) *net.IPNet {
+	_, n, err := net.ParseCIDR(cidr)
+	if err != nil {
+		panic(err)
+	}
+	return n
+}
+
+var internalCIDRs4 = []*net.IPNet{
+	mustGetCIDRNetwork("10.0.0.0/8"),
+	mustGetCIDRNetwork("172.16.0.0/12"),
+	mustGetCIDRNetwork("192.168.0.0/16"),
+	mustGetCIDRNetwork("169.254.0.0/16"),
+}
+
+var internalCIDRs6 = []*net.IPNet{
+	mustGetCIDRNetwork("fd00::/8"),
+}
+
+func ipIsPrivate(ip net.IP) bool {
+	cidrs := internalCIDRs4
+	if ip.To4() == nil {
+		cidrs = internalCIDRs6
+	}
+	for _, cidr := range cidrs {
+		if cidr.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// RequestIP returns the string form of the original requester's IP address for
+// the given request, taking into account X-Forwarded-For if applicable.
+func RequestIP(r *http.Request) string {
+	reqIP, _, _ := net.SplitHostPort(r.RemoteAddr)
+
+	xff := r.Header.Get("X-Forwarded-For")
+	if xff == "" {
+		return reqIP
+	}
+
+	ips := strings.Split(xff, ",")
+	for i := range ips {
+		ip := net.ParseIP(strings.TrimSpace(ips[i]))
+		if ip == nil || ip.IsLoopback() || ipIsPrivate(ip) {
+			continue
+		}
+		reqIP = ip.String()
+		break
+	}
+
+	return reqIP
+}

--- a/rpcutil/xff_test.go
+++ b/rpcutil/xff_test.go
@@ -1,0 +1,53 @@
+package rpcutil
+
+import (
+	"net/http"
+	"strings"
+	. "testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func assertXFF(t *T, addrExpect, addrIn string, forwards ...string) {
+	r, err := http.NewRequest("GET", "/", nil)
+	require.Nil(t, err)
+	r.RemoteAddr = addrIn
+	if len(forwards) > 0 {
+		r.Header.Set("X-Forwarded-For", strings.Join(forwards, ", "))
+	}
+	out := RequestIP(r)
+	assert.Equal(t, addrExpect, out, "addrIn: %q forwards: %v", addrIn, forwards)
+}
+
+func TestXFF(t *T) {
+	// Some basic sanity checks
+	assertXFF(t, "8.8.8.8", "8.8.8.8:2000")
+	assertXFF(t, "::ffff:8.8.8.8", "[::ffff:8.8.8.8]:2000")
+
+	// IPv4
+	assertXFF(t, "8.8.8.8", "1.1.1.1:2000",
+		"8.8.8.8")
+	assertXFF(t, "1.1.1.1", "1.1.1.1:2000",
+		"127.0.0.1")
+	assertXFF(t, "1.1.1.1", "1.1.1.1:2000",
+		"127.0.0.1", "192.168.1.1")
+	assertXFF(t, "8.8.8.8", "1.1.1.1:2000",
+		"127.0.0.1", "192.168.1.1", "8.8.8.8")
+	assertXFF(t, "8.8.8.8", "1.1.1.1:2000",
+		"127.0.0.1", "192.168.1.1", "8.8.8.8", "9.9.9.9")
+
+	// IPv6
+	assertXFF(t, "1::1", "1.1.1.1:2000",
+		"1::1")
+	assertXFF(t, "8.8.8.8", "1.1.1.1:2000",
+		"::ffff:8.8.8.8")
+	assertXFF(t, "1.1.1.1", "1.1.1.1:2000",
+		"fd00::1")
+	assertXFF(t, "1.1.1.1", "1.1.1.1:2000",
+		"fd00::1", "::1")
+	assertXFF(t, "1::1", "1.1.1.1:2000",
+		"fd00::1", "::1", "1::1")
+	assertXFF(t, "1::1", "1.1.1.1:2000",
+		"fd00::1", "::1", "1::1", "2::2")
+}


### PR DESCRIPTION
This is half copied from an open-source project I worked on previously: https://github.com/mediocregopher/mediocre-api/tree/master/xff
